### PR TITLE
Remove oxidized CH4 emissions from SNEASY carbon cycle

### DIFF
--- a/src/MimiSNEASY.jl
+++ b/src/MimiSNEASY.jl
@@ -69,8 +69,7 @@ function getsneasy(;start_year::Int=1765, end_year::Int=2500)
     set_param!(m, :ccm, :atmco20, 280.)
     set_param!(m, :ccm, :CO2_emissions, f_co2emissions)
     set_param!(m, :ccm, :anomtable, anomtable)
-    # TODO Find better values for the following two parameters
-    set_param!(m, :ccm, :oxidised_CH₄_to_CO₂, zeros(nsteps))
+    # TODO Find better values for the following parameter
     set_param!(m, :rfco2, :N₂O, fill(272.95961, nsteps))
 
     set_param!(m, :radiativeforcing, :rf_aerosol, f_rfaerosol)

--- a/src/components/ccm.jl
+++ b/src/components/ccm.jl
@@ -53,7 +53,6 @@ const npp0 = 60.0             # [GtC/yr]
     Eta = Parameter() #default 16.88,   diffusion coeffs [m/yr]
     temp = Parameter(index=[time])
     CO2_emissions = Parameter(index=[time])
-    oxidised_CH₄_to_CO₂          =Parameter(index=[time]) #CO2 emissions form CH4 oxidation
 
     # Set anomtable to be a parameter, indexed by anom_row and anom_col
     anomtable = Parameter(index =[anom_row, anom_col])
@@ -109,7 +108,7 @@ const npp0 = 60.0             # [GtC/yr]
             end
         end
     
-        netemissions = p.CO2_emissions[t] + v.landflux[t] + p.oxidised_CH₄_to_CO₂[t]
+        netemissions = p.CO2_emissions[t] + v.landflux[t]
     
         # Find fracinoc using the ocean anomaly table.
         fracinoc = anom_interp(p.anomtable, p.temp[t], v.ocanom[t,1]+netemissions)


### PR DESCRIPTION
Remove the oxidized CH4 to CO2 emissions term from the SNEASY carbon cycle. This calculation should be done in a different component.