### PR TITLE
Rename getsneasy to get_model

### DIFF
--- a/calibration/run_mimi_sneasy.jl
+++ b/calibration/run_mimi_sneasy.jl
@@ -1,7 +1,7 @@
 include("../src/sneasy.jl")
 
 function construct_run_mimi_sneasy()
-    m = getsneasy(nsteps=246)
+    m = get_model(nsteps=246)
 
     function run_mimi_sneasy!(
 	       MOC_strength::Vector{Float64},

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,5 +1,5 @@
 include("sneasy.jl")
 
-m = getsneasy()
+m = get_model()
 
 run(m)

--- a/examples/perftest.jl
+++ b/examples/perftest.jl
@@ -7,7 +7,7 @@ function doruns(model)
     end
 end
 
-m = getsneasy()
+m = get_model()
 run(m)
 
 @time doruns(m)

--- a/src/MimiSNEASY.jl
+++ b/src/MimiSNEASY.jl
@@ -10,7 +10,7 @@ include("components/ccm.jl")
 include("components/radiativeforcing.jl")
 include("components/rfco2.jl")
 
-function getsneasy(;start_year::Int=1765, end_year::Int=2500)
+function get_model(;start_year::Int=1765, end_year::Int=2500)
     m = Model()
 
     set_dimension!(m, :time, start_year:end_year)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Test
 # include("test_doeclim.jl")
 # include("test_sneasy.jl")
 
-m = MimiSNEASY.getsneasy()
+m = MimiSNEASY.get_model()
 run(m)
 
 end


### PR DESCRIPTION
This will require a small adjustment in code that uses this, but gets this package in line with the pattern we've been using in all the other models.

@ckingdon95 can you also take a quick look whether this now conforms with the pattern that you've introduced everywhere else?